### PR TITLE
Add sccache to PATH after installation

### DIFF
--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -59695,6 +59695,7 @@ async function installSccacheFromGitHub(version, artifactName, binSha256, binDir
     const binPath = external_path_default().join(binDir, binName);
     await downloadAndExtract(url, `*/${binName}`, binPath);
     checkSha256Sum(binPath, binSha256);
+    core.addPath(binDir);
     await execBash(`chmod +x '${binPath}'`);
 }
 async function downloadAndExtract(url, srcFile, dstFile) {

--- a/src/restore.ts
+++ b/src/restore.ts
@@ -150,6 +150,7 @@ async function installSccacheFromGitHub(version : string, artifactName : string,
   const binPath = path.join(binDir, binName);
   await downloadAndExtract(url, `*/${binName}`, binPath);
   checkSha256Sum(binPath, binSha256);
+  core.addPath(binDir);
   await execBash(`chmod +x '${binPath}'`);
 }
 


### PR DESCRIPTION
The action installs sccache under $USERPROFILE/.cargo/bin. GitHub runner images already have $USERPROFILE/.cargo/bin in the PATH, but self-hosted runners may not. This PR makes this action update the user's PATH to include the installation directory. This allows self-hosted runners to find sccache and prevents breakages in the unlikely event that a different installation directory is chosen in the future.